### PR TITLE
chore: update .swift-format

### DIFF
--- a/.swift-format
+++ b/.swift-format
@@ -55,6 +55,7 @@
     "ReturnVoidInsteadOfEmptyTuple" : true,
     "TypeNamesShouldBeCapitalized" : true,
     "UseEarlyExits" : true,
+    "UseExplicitNilCheckInConditions" : true,
     "UseLetInEveryBoundCaseVariable" : true,
     "UseShorthandTypeNames" : true,
     "UseSingleLinePropertyGetter" : true,


### PR DESCRIPTION
swift-format for Swift 6.0 now has a new rule.