### PR TITLE
chore: refactor Package.swift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,6 +37,5 @@ let package = Package(
                 .unsafeFlags(["-I", "\(home)/Developer/PlaydateSDK/C_API"]),
             ]
         )
-    ],
-    swiftLanguageVersions: [.version("6")]
+    ]
 )


### PR DESCRIPTION
It's not needed for this repo because Swift compiles code in the Swift 6 language mode when `swift-tools-version` is `6.0`. By the way, `swiftLanguageVersions` is now `swiftLanguageModes`.